### PR TITLE
Add some functions on sequences of Results

### DIFF
--- a/FsToolkit/Result.fs
+++ b/FsToolkit/Result.fs
@@ -31,7 +31,14 @@ module Result =
         rs
         |> Seq.groupBy isOk
         |> Map.ofSeq
-        |> (fun m -> (Map.tryFind true m, Map.tryFind false m)
+        |> (fun m ->
+            let oks = Map.tryFind true m
+                      |> Option.map (Seq.map (fun r -> match r with | Ok x -> x | x -> failwithf "Unexpected result: %A" x))
+                      |> (fun rs -> match rs with | None -> Seq.empty | Some x -> x)
+            let errs = Map.tryFind false m
+                       |> Option.map (Seq.map (fun r -> match r with | Error x -> x | x -> failwithf "Unexpected result: %A" x))
+                       |> (fun rs -> match rs with | None -> Seq.empty | Some x -> x)
+            (oks, errs))
 
     let oks rs =
         rs

--- a/FsToolkit/Result.fs
+++ b/FsToolkit/Result.fs
@@ -23,27 +23,25 @@ module Result =
         | Ok x -> Ok(f x)
         | Error x -> Error x
 
-    let oks rs =
-        Seq.filter
-            (fun r ->
-                match r with
-                | Ok _ -> true
-                | _ -> false)
-            rs
-
-    let errors rs =
-        Seq.filter
-            (fun r ->
-                match r with
-                | Error _ -> true
-                | _ -> false)
-            rs
-
     let partition rs =
-        let isOk = (fun r -> match r with | Ok _ -> true | _ -> false)
+        let isOk r =
+            match r with
+            | Ok _ -> true
+            | _ -> false
         rs
         |> Seq.groupBy isOk
-        |> Seq.map snd
+        |> Map.ofSeq
+        |> (fun m -> (Map.tryFind true m, Map.tryFind false m)
+
+    let oks rs =
+        rs
+        |> partition
+        |> fst
+
+    let errors rs =
+        rs
+        |> partition
+        |> snd
 
 module AsyncResult =
     let bind f r = async {

--- a/FsToolkit/Result.fs
+++ b/FsToolkit/Result.fs
@@ -23,6 +23,28 @@ module Result =
         | Ok x -> Ok(f x)
         | Error x -> Error x
 
+    let oks rs =
+        Seq.filter
+            (fun r ->
+                match r with
+                | Ok _ -> true
+                | _ -> false)
+            rs
+
+    let errors rs =
+        Seq.filter
+            (fun r ->
+                match r with
+                | Error _ -> true
+                | _ -> false)
+            rs
+
+    let partition rs =
+        let isOk = (fun r -> match r with | Ok _ -> true | _ -> false)
+        rs
+        |> Seq.groupBy isOk
+        |> Seq.map snd
+
 module AsyncResult =
     let bind f r = async {
         let! r = r


### PR DESCRIPTION
Given a `Seq<Result<a,b>>`, we should have functions that act on it to return `Seq<a>`, `Seq<b>`, and `(Seq<a>,Seq<b>)`